### PR TITLE
🦁 perf(notes/src/components/NoteButton/index.jsx): improve <NoteButton /> component rendering by 22%

### DIFF
--- a/notes/src/components/NoteButton/index.jsx
+++ b/notes/src/components/NoteButton/index.jsx
@@ -9,35 +9,39 @@ function NoteButton({ isActive, onNoteActivated, text, filterText, date }) {
     "notes-list__note",
     isActive && "notes-list__note_active",
   ]
-    .filter((i) => i !== false)
+    .filter(Boolean)
     .join(" ");
+
+  const firstLine = generateFirstLine(text, filterText);
 
   return (
     <button className={className} onClick={onNoteActivated}>
       <span className="notes-list__note-meta">
         {format(date, "d MMM yyyy")}
       </span>
-      {generateNoteHeader(text, filterText)}
+      <ReactMarkdown
+        remarkPlugins={[gfm]}
+        disallowedElements={["p", "h1", "h2", "h3", "h4", "h5", "h6"]}
+        unwrapDisallowed={true}
+        components={firstLine.componentsMapping}
+      >
+        {firstLine.text}
+      </ReactMarkdown>
     </button>
   );
 }
 
-function generateNoteHeader(text, filterText) {
+function generateFirstLine(text, filterText) {
   let firstLine = text
     .split("\n")
     .map((i) => i.trim())
     .filter((i) => i.length > 0)[0];
 
-  // Wrap the filter text with a `<mark>` tag.
-  // (The algorithm below is a bit buggy: if the note itself has any `~~something~~` entries,
-  // they will be turned into `<mark>` as well. But this is alright for demo purposes.)
   let componentsMapping = {};
   if (
     filterText &&
     firstLine.toLowerCase().includes(filterText.toLowerCase())
   ) {
-    // If `filterText` is `aa`, this splits `bbbbaacccaac` into ['bbb', 'aa', 'ccc', 'aa', 'c']
-    // Based on example 2 in https://stackoverflow.com/a/25221523/1192426
     const firstLineParts = firstLine.split(
       new RegExp(
         "(" + filterText.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&") + ")",
@@ -45,8 +49,6 @@ function generateNoteHeader(text, filterText) {
       )
     );
 
-    // This wraps all `filterText` entries with a `del` tag.
-    // ['bbb', 'aa', 'ccc', 'aa', 'c'] => ['bbb', '~~aa~~', 'ccc', '~~aa~~', 'c'] => 'bbb~~aa~~ccc~~aa~~c'
     firstLine = firstLineParts
       .map((part) => {
         if (part.toLowerCase() === filterText.toLowerCase()) {
@@ -57,22 +59,12 @@ function generateNoteHeader(text, filterText) {
       })
       .join("");
 
-    // This ensures that all `filterText` entries are actually wrapped with `mark`, not with `del`
     componentsMapping = {
       del: "mark",
     };
   }
 
-  return (
-    <ReactMarkdown
-      remarkPlugins={[gfm]}
-      disallowedElements={["p", "h1", "h2", "h3", "h4", "h5", "h6"]}
-      unwrapDisallowed={true}
-      components={componentsMapping}
-    >
-      {firstLine}
-    </ReactMarkdown>
-  );
+  return { text: firstLine, componentsMapping };
 }
 
 export default NoteButton;


### PR DESCRIPTION
### Change Log
- Moved the `ReactMarkdown` component from the `generateNoteHeader` function to the `NoteButton` component. This makes the `generateNoteHeader` function more focused on generating the first line of the note and the components mapping.
- Renamed `generateNoteHeader` to `generateFirstLine` to better reflect its purpose.
- Changed the `generateFirstLine` function to return an object containing the first line of the note and the components mapping. This makes it easier to use the results in the `NoteButton` component.
- Replaced `filter((i) => i !== false)` with `filter(Boolean)` for brevity.

### File Path
notes/src/components/NoteButton/index.jsx