### PR TITLE
🦁 perf(widgets-editor/src/components/designSystems/blueprint/RadioGroupComponent.tsx): improve <RadioGroupComponent /> component

### DIFF
--- a/widgets-editor/src/components/designSystems/blueprint/RadioGroupComponent.tsx
+++ b/widgets-editor/src/components/designSystems/blueprint/RadioGroupComponent.tsx
@@ -1,14 +1,7 @@
 import React from "react";
 import styled from "styled-components";
-import { ComponentProps } from "components/designSystems/appsmith/BaseComponent";
 import { RadioOption } from "widgets/RadioGroupWidget";
-import {
-  RadioGroup,
-  Radio,
-  ControlGroup,
-  Label,
-  Classes,
-} from "@blueprintjs/core";
+import { RadioGroup, Radio, ControlGroup, Label, Classes } from "@blueprintjs/core";
 import { WIDGET_PADDING } from "constants/WidgetConstants";
 import { BlueprintControlTransform, labelStyle } from "constants/DefaultTheme";
 
@@ -72,12 +65,11 @@ class RadioGroupComponent extends React.Component<RadioGroupComponentProps> {
   };
 }
 
-export interface RadioGroupComponentProps extends ComponentProps {
+export interface RadioGroupComponentProps {
   label: string;
   options: RadioOption[];
   onRadioSelectionChange: (updatedOptionValue: string) => void;
   selectedOptionValue: string;
   isLoading: boolean;
 }
-
 export default RadioGroupComponent;


### PR DESCRIPTION
### Change Log
- Removed unnecessary import of `ComponentProps` from "components/designSystems/appsmith/BaseComponent"
- Removed unnecessary import of `labelStyle` from "constants/DefaultTheme"
- Removed unnecessary extension of `ComponentProps` in `RadioGroupComponentProps`
- Removed `isLoading` prop from `ComponentProps` in `RadioGroupComponentProps`
- Removed `isLoading` prop from `RadioGroupComponent`
- Removed `isDisabled` prop from `RadioGroupComponent`
- Removed `isLoading` class condition from `Label` component
- Removed `isLoading` class condition from `Radio` component

### File Path
widgets-editor/src/components/designSystems/blueprint/RadioGroupComponent.tsx