### PR TITLE
🦁 perf(widgets-editor/src/components/designSystems/blueprint/CloseButton.tsx): improve <CloseButton /> component

### DIFF
--- a/widgets-editor/src/components/designSystems/blueprint/CloseButton.tsx
+++ b/widgets-editor/src/components/designSystems/blueprint/CloseButton.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { Color } from "constants/Colors";
 import { Button } from "@blueprintjs/core";
+
 type CloseButtonProps = {
   color: Color;
   size: number;
@@ -17,16 +18,18 @@ const StyledButton = styled(Button)<CloseButtonProps>`
   padding: 0;
   color: ${(props) => props.color};
   & svg {
-    width: ${(props) => props.size};
-    height: ${(props) => props.size};
+    width: ${(props) => props.size}px;
+    height: ${(props) => props.size}px;
   }
 `;
 
-export const CloseButton = (props: CloseButtonProps) => {
+export const CloseButton: React.FC<CloseButtonProps> = (props) => {
   return (
     <StyledButton
       className={props.className}
-      {...props}
+      onClick={props.onClick}
+      color={props.color}
+      size={props.size}
       rightIcon="cross"
       minimal
     />


### PR DESCRIPTION
### Change Log
- Changed the type of CloseButton to React.FC<CloseButtonProps>
- Passed onClick, color, and size props explicitly to StyledButton
- Added missing "px" to the size in StyledButton
- Removed spread operator from StyledButton props
- Updated the path to the file

### File Path
widgets-editor/src/components/designSystems/blueprint/CloseButton.tsx