### PR TITLE
🦁 perf(widgets-editor/src/components/editorComponents/ReadOnlyEditor.tsx): improve <ReadOnlyEditor /> component

### DIFF
--- a/widgets-editor/src/components/editorComponents/ReadOnlyEditor.tsx
+++ b/widgets-editor/src/components/editorComponents/ReadOnlyEditor.tsx
@@ -1,14 +1,7 @@
-import React, { ChangeEvent } from "react";
-import {
-  EditorModes,
-  EditorSize,
-  EditorTheme,
-  TabBehaviour,
-} from "components/editorComponents/CodeEditor/EditorConfig";
+import React, { ChangeEvent, lazy, Suspense } from "react";
+import { EditorProps, EditorModes, EditorSize, EditorTheme, TabBehaviour } from "components/editorComponents/CodeEditor/EditorConfig";
 
-const CodeEditorLazy = React.lazy(() =>
-  import("components/editorComponents/CodeEditor"),
-);
+const CodeEditor = lazy(() => import("components/editorComponents/CodeEditor"));
 
 interface Props {
   input: {
@@ -34,7 +27,11 @@ const ReadOnlyEditor = (props: Props) => {
     borderLess: true,
     folding: props.folding,
   };
-  return <CodeEditorLazy {...editorProps} />;
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <CodeEditor {...editorProps} />
+    </Suspense>
+  );
 };
 
 export default ReadOnlyEditor;


### PR DESCRIPTION
### Change Log
- Changed the import of `React.lazy` and `Suspense` to lazy load the `CodeEditor` component.
- Updated the import of `EditorProps` and `EditorModes` from the `EditorConfig` file.
- Wrapped the `CodeEditor` component with `Suspense` and added a fallback UI for lazy loading.
- Updated the import of `CodeEditor` component. 

### File Path
widgets-editor/src/components/editorComponents/ReadOnlyEditor.tsx